### PR TITLE
Fix story 9 - Use command with "image-filter.exe"

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -43,6 +43,8 @@ if sys.argv.__contains__("--filters" and "--i" and "--o"):
             print("Wrong parameters. Please use --help.")
     else:
         print("Wrong parameters usage. Please use --help.")
+elif sys.argv.__contains__("--help"):
+    print("Usage: python")
 else:
     print("Wrong command usage. Please use --help.")
 

--- a/image-filter.exe
+++ b/image-filter.exe
@@ -1,0 +1,1 @@
+C:/Users/pennm/GITRepo/python-image-editor/main.py

--- a/main.py
+++ b/main.py
@@ -1,1 +1,3 @@
+#!/usr/bin/env python3
+
 from cli import *


### PR DESCRIPTION
I've added an executable to run commands using "image-filter".
Example: image-filter --filters "grey&rotate:10" --i img/nishikata.jpg --o img/
To create this executable I :
1. Added `#!/usr/bin/env python3` at the beginning of main.py
2. Made sure the script was executable: 
`takeown /f C:\Users\pennm\GITRepo\python-image-editor\main.py`
`icacls C:\Users\pennm\GITRepo\python-image-editor\main.py /grant:r "$($env:USERNAME):(RX)"`
3. Added an entry in PATH : 
`$env:PATH += ";C:\Users\pennm\GITRepo\python-image-editor\"`
This command only work for the current powershell session so I created a powershell profile and added the command into the profile (`notepad $PROFILE`)
4. Finally, I created a symbolic link between main.py and a new .exe file :
`New-Item -ItemType SymbolicLink -Path C:\Users\pennm\GITRepo\python-image-editor\image-filter.exe -Target C:\Users\pennm\GITRepo\python-image-editor\main.py
`
You must run this command as administrator in powershell, otherwise it won't work.

Now we can use the commands as requested in the backlog (a.g. story 9)
like : `image-filter --filters “gray&rotate:55” --i img --o output/`

